### PR TITLE
auth token in response and unit tests

### DIFF
--- a/appstore/core/tests.py
+++ b/appstore/core/tests.py
@@ -2,6 +2,7 @@ import logging
 
 from core.admin_tests import *
 from core.views import form_service_url
+from django.http import HttpResponse, HttpResponseRedirect
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,26 @@ class AppTests(TestCase):
             'action': 'delete'
         })
         self.assertEqual(response.status_code, 302)
+
+    def test_auth_loggedin_admin_user(self):
+        """Test the auth endpoint for a logged in User"""
+        logger.info(f"-- testing auth endpoint for logged in admin user")
+        credentials = {'username': 'admin', 'password': 'admin'}
+        self.client.login(**credentials)
+        response = self.client.get("/auth/")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(isinstance(response, HttpResponse))
+        header_ak, access_token = response._headers.get("access_token")
+        self.assertEqual(access_token, "")
+        header_rm, remote_user = response._headers.get("remote_user")
+        self.assertEqual(remote_user, "admin")
+
+    def test_auth_nonloggedin_user(self):
+        logger.info(f"-- testing auth endpoint for non logged in user")
+        response = self.client.get("/auth/")
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(isinstance(response, HttpResponseRedirect))
+        self.assertEqual(response.url, "/accounts/login?next=/auth/")
 
     def test_form_service_url(self):
         """Testing the form service url by passing mock data."""


### PR DESCRIPTION
Update:

- Receive a notification from a signal emitted by django allauth during the oauth2 login, to capture the access token. Store it in the user session. where every view has access to it.
- Send the access_token in response to a request to auth endpoint.
- unit tests