### PR TITLE
Add download link to product settings

### DIFF
--- a/appstore/api/v1/serializers.py
+++ b/appstore/api/v1/serializers.py
@@ -8,26 +8,26 @@ logger = logging.getLogger(__name__)
 
 
 class InstanceSerializer(serializers.Serializer):
-    name = serializers.CharField(required=True)
-    docs = serializers.CharField(required=True)
-    sid = serializers.CharField(required=True)
-    fqsid = serializers.CharField(required=True)
-    creation_time = serializers.CharField(
-        required=True
+    name = serializers.CharField()
+    docs = serializers.CharField()
+    sid = serializers.CharField()
+    fqsid = serializers.CharField()
+    creation_time = (
+        serializers.CharField()
     )  # serializers.DateTimeField(format='iso-8601') - date error from tycho
-    cpus = serializers.FloatField(required=True)
+    cpus = serializers.FloatField()
     gpus = serializers.IntegerField(default=0)
     # TODO switch to Float potentially, or validator
-    memory = serializers.CharField(required=True)
+    memory = serializers.CharField()
 
 
 class AppDetailSerializer(serializers.Serializer):
-    name = serializers.CharField(required=True)
-    app_id = serializers.CharField(required=True)
-    description = serializers.CharField(required=True)
-    detail = serializers.CharField(required=True)
-    docs = serializers.CharField(required=True)
-    spec = serializers.CharField(required=True)
+    name = serializers.CharField()
+    app_id = serializers.CharField()
+    description = serializers.CharField()
+    detail = serializers.CharField()
+    docs = serializers.CharField()
+    spec = serializers.CharField()
     minimum_resources = serializers.DictField()
     maximum_resources = serializers.DictField()
 
@@ -37,41 +37,42 @@ class AppSerializer(serializers.Serializer):
 
 
 class ResourceSerializer(serializers.Serializer):
-    app_id = serializers.CharField(required=True)
-    cpus = serializers.FloatField(required=True)
+    app_id = serializers.CharField()
+    cpus = serializers.FloatField()
     gpus = serializers.IntegerField(default=0)
-    memory = serializers.CharField(required=True, validators=[memory_format_validator])
+    memory = serializers.CharField(validators=[memory_format_validator])
 
     def create(self, validated_data):
         return ResourceRequest(**validated_data)
 
 
 class InstanceSpecSerializer(serializers.Serializer):
-    username = serializers.CharField(required=True)
-    app_id = serializers.CharField(required=True)
-    name = serializers.CharField(required=True)
-    host = serializers.CharField(required=True)
-    resources = serializers.DictField(required=True)
-    url = serializers.CharField(required=True)
-    protocol = serializers.CharField(required=True)
+    username = serializers.CharField()
+    app_id = serializers.CharField()
+    name = serializers.CharField()
+    host = serializers.CharField()
+    resources = serializers.DictField()
+    url = serializers.CharField()
+    protocol = serializers.CharField()
 
 
 class InstanceIdentifierSerializer(serializers.Serializer):
-    sid = serializers.CharField(required=True)
+    sid = serializers.CharField()
 
 
 class UserSerializer(serializers.Serializer):
-    REMOTE_USER = serializers.CharField(required=True)
-    ACCESS_TOKEN = serializers.CharField(required=True)
+    REMOTE_USER = serializers.CharField()
+    ACCESS_TOKEN = serializers.CharField()
 
 
 class LoginProviderSerializer(serializers.Serializer):
-    name = serializers.CharField(required=True)
-    url = serializers.CharField(required=True)
+    name = serializers.CharField()
+    url = serializers.CharField()
 
 
 class AppContextSerializer(serializers.Serializer):
-    brand = serializers.CharField(required=True)
-    logo_url = serializers.CharField(required=True)
-    title = serializers.CharField(required=True)
-    colors = serializers.DictField(required=True)
+    brand = serializers.CharField()
+    title = serializers.CharField()
+    logo_url = serializers.CharField()
+    color_scheme = serializers.DictField()
+    links = serializers.ListField(required=False)

--- a/appstore/api/v1/views.py
+++ b/appstore/api/v1/views.py
@@ -35,7 +35,7 @@ Tycho context for application management.
 Manages application metadata, discovers and invokes TychoClient, etc.
 """
 tycho = ContextFactory.get(
-    context_type=settings.TYCHO_MODE, product=settings.APPLICATION_SETTINGS.brand
+    context_type=settings.TYCHO_MODE, product=settings.PRODUCT_SETTINGS.brand
 )
 
 
@@ -446,7 +446,7 @@ class LoginProviderViewSet(viewsets.GenericViewSet):
         Check for SSO defined in appstore settings.
         """
 
-        if settings.APPLICATION_SETTINGS.brand in ("braini", "restarts"):
+        if settings.PRODUCT_SETTINGS.brand in ("braini", "restarts"):
             # TODO can we get the provider name from metadata so that if
             # we support something beyond UNC we dont need another func
             # or clause? What happens if we have multiple SAML SSO providers
@@ -487,7 +487,7 @@ class LoginProviderViewSet(viewsets.GenericViewSet):
 
 class AppContextViewSet(viewsets.GenericViewSet):
     """
-    Application configuration information.
+    Brand/Product configuration information.
     """
 
     permission_classes = [AllowAny]
@@ -498,6 +498,6 @@ class AppContextViewSet(viewsets.GenericViewSet):
 
     def list(self, request):
         settings = self.get_queryset()
-        serializer = self.get_serializer(data=asdict(settings.APPLICATION_SETTINGS))
+        serializer = self.get_serializer(data=asdict(settings.PRODUCT_SETTINGS))
         serializer.is_valid(raise_exception=True)
         return Response(serializer.validated_data)

--- a/appstore/appstore/settings/braini_settings.py
+++ b/appstore/appstore/settings/braini_settings.py
@@ -5,7 +5,7 @@ from .product import ProductSettings, ProductColorScheme, ProductLink
 # the django templates in core are removed.
 APPLICATION_BRAND = "braini"
 
-APPLICATION_SETTINGS = ProductSettings(
+PRODUCT_SETTINGS = ProductSettings(
     brand="braini",
     title="Brain-I",
     logo_url="/static/images/braini/braini-lg-gray.png",

--- a/appstore/appstore/settings/braini_settings.py
+++ b/appstore/appstore/settings/braini_settings.py
@@ -1,32 +1,38 @@
 from .base import *
+from .product import ProductSettings, ProductColorScheme, ProductLink
 
+# TODO remove Application brand once the new frontend is complete and
+# the django templates in core are removed.
 APPLICATION_BRAND = "braini"
-APPLICATION_TITLE = "Brain-I"
-APPLICATION_LOGO = "/static/images/braini/braini-lg-gray.png"
-APPLICATION_COLOR = {
-  "primary": "#666666",
-  "secondary": "#e6e6e6"
-}
+
+APPLICATION_SETTINGS = ProductSettings(
+    brand="braini",
+    title="Brain-I",
+    logo_url="/static/images/braini/braini-lg-gray.png",
+    color_scheme=ProductColorScheme("#666666", "#e6e6e6"),
+    links=[ProductLink("Image Download", IMAGE_DOWNLOAD_URL)],
+)
 
 SAML2_AUTH = {
     # Metadata is required, choose either remote url or local file path
-    'METADATA_AUTO_CONF_URL': 'https://sso.unc.edu/metadata/unc',
-
+    "METADATA_AUTO_CONF_URL": "https://sso.unc.edu/metadata/unc",
     # Optional settings below
-    'DEFAULT_NEXT_URL': '/apps/',  # Custom target redirect URL after the user get logged in. Default to /admin if not set. This setting will be overwritten if you have parameter ?next= specificed in the login URL.
-    'CREATE_USER': 'TRUE', # Create a new Django user when a new user logs in. Defaults to True.
-    'NEW_USER_PROFILE': {
-        'USER_GROUPS': [],  # The default group name when a new user logs in
-        'ACTIVE_STATUS': True,  # The default active status for new users
-        'STAFF_STATUS': True,  # The staff status for new users
-        'SUPERUSER_STATUS': False,  # The superuser status for new users
+    "DEFAULT_NEXT_URL": "/apps/",  # Custom target redirect URL after the user get logged in. Default to /admin if not set. This setting will be overwritten if you have parameter ?next= specificed in the login URL.
+    "CREATE_USER": "TRUE",  # Create a new Django user when a new user logs in. Defaults to True.
+    "NEW_USER_PROFILE": {
+        "USER_GROUPS": [],  # The default group name when a new user logs in
+        "ACTIVE_STATUS": True,  # The default active status for new users
+        "STAFF_STATUS": True,  # The staff status for new users
+        "SUPERUSER_STATUS": False,  # The superuser status for new users
     },
-    'ATTRIBUTES_MAP': {  # Change Email/UserName/FirstName/LastName to corresponding SAML2 userprofile attributes.
-        'email': 'mail',
-        'username': 'uid',
-        'first_name': 'givenName',
-        'last_name': 'sn',
+    "ATTRIBUTES_MAP": {  # Change Email/UserName/FirstName/LastName to corresponding SAML2 userprofile attributes.
+        "email": "mail",
+        "username": "uid",
+        "first_name": "givenName",
+        "last_name": "sn",
     },
-    'ASSERTION_URL': os.environ.get('SAML2_AUTH_ASSERTION_URL'),
-    'ENTITY_ID': os.environ.get('SAML2_AUTH_ENTITY_ID'), # Populates the Issuer element in authn request
+    "ASSERTION_URL": os.environ.get("SAML2_AUTH_ASSERTION_URL"),
+    "ENTITY_ID": os.environ.get(
+        "SAML2_AUTH_ENTITY_ID"
+    ),  # Populates the Issuer element in authn request
 }

--- a/appstore/appstore/settings/cat_settings.py
+++ b/appstore/appstore/settings/cat_settings.py
@@ -3,7 +3,7 @@ from .product import ProductSettings, ProductColorScheme
 
 APPLICATION_BRAND = "catalyst"
 
-APPLICATION_SETTINGS = ProductSettings(
+PRODUCT_SETTINGS = ProductSettings(
     brand="catalyst",
     title="Biodata Catalyst",
     logo_url="/static/images/catalyst/bdc-logo.svg",

--- a/appstore/appstore/settings/cat_settings.py
+++ b/appstore/appstore/settings/cat_settings.py
@@ -1,9 +1,12 @@
 from .base import *
+from .product import ProductSettings, ProductColorScheme
 
 APPLICATION_BRAND = "catalyst"
-APPLICATION_TITLE = "Biodata Catalyst"
-APPLICATION_LOGO = "/static/images/catalyst/bdc-logo.svg"
-APPLICATION_COLOR = {
-  "primary": "#b33243",
-  "secondary": "#606264"
-}
+
+APPLICATION_SETTINGS = ProductSettings(
+    brand="catalyst",
+    title="Biodata Catalyst",
+    logo_url="/static/images/catalyst/bdc-logo.svg",
+    color_scheme=ProductColorScheme("#b33243", "#606264"),
+    links=None,
+)

--- a/appstore/appstore/settings/product.py
+++ b/appstore/appstore/settings/product.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+@dataclass
+class ProductColorScheme:
+    """
+    Per product hex colors
+    """
+    primary: str = "#00a8c1"
+    secondary: str = "#d2cbcb"
+
+@dataclass
+class ProductLink:
+    """
+    Per product links
+    """
+    title: str
+    link: str
+
+@dataclass
+class ProductSettings:
+    """
+    Per product application settings.
+
+    Defaults to Common Share product settings.
+    """
+    links: Optional[List[ProductLink]]
+    brand: str = "CommonsShare"
+    title: str = "CommonsShare"
+    logo_url: str = "/static/images/commonsshare/logo-lg.png"
+    color_scheme: ProductColorScheme = ProductColorScheme()

--- a/appstore/appstore/settings/restartr_settings.py
+++ b/appstore/appstore/settings/restartr_settings.py
@@ -3,7 +3,7 @@ from .product import ProductSettings, ProductColorScheme
 
 APPLICATION_BRAND = "restartr"
 
-APPLICATION_SETTINGS = ProductSettings(
+PRODUCT_SETTINGS = ProductSettings(
     brand="restartr",
     title="Restarting Research",
     logo_url="/static/images/restartr/restartingresearch.png",

--- a/appstore/appstore/settings/restartr_settings.py
+++ b/appstore/appstore/settings/restartr_settings.py
@@ -1,32 +1,36 @@
 from .base import *
+from .product import ProductSettings, ProductColorScheme
 
 APPLICATION_BRAND = "restartr"
-APPLICATION_TITLE = "Restarting Research"
-APPLICATION_LOGO = "/static/images/restartr/restartingresearch.png"
-APPLICATION_COLOR = {
-  "primary": "#ff6320",
-  "secondary": "#ffd220"
-}
+
+APPLICATION_SETTINGS = ProductSettings(
+    brand="restartr",
+    title="Restarting Research",
+    logo_url="/static/images/restartr/restartingresearch.png",
+    color_scheme=ProductColorScheme("#ff6320", "#ffd220"),
+    links=None,
+)
 
 SAML2_AUTH = {
     # Metadata is required, choose either remote url or local file path
-    'METADATA_AUTO_CONF_URL': 'https://sso.unc.edu/metadata/unc',
-
+    "METADATA_AUTO_CONF_URL": "https://sso.unc.edu/metadata/unc",
     # Optional settings below
-    'DEFAULT_NEXT_URL': '/apps/',  # Custom target redirect URL after the user get logged in. Default to /admin if not set. This setting will be overwritten if you have parameter ?next= specificed in the login URL.
-    'CREATE_USER': 'TRUE', # Create a new Django user when a new user logs in. Defaults to True.
-    'NEW_USER_PROFILE': {
-        'USER_GROUPS': [],  # The default group name when a new user logs in
-        'ACTIVE_STATUS': True,  # The default active status for new users
-        'STAFF_STATUS': True,  # The staff status for new users
-        'SUPERUSER_STATUS': False,  # The superuser status for new users
+    "DEFAULT_NEXT_URL": "/apps/",  # Custom target redirect URL after the user get logged in. Default to /admin if not set. This setting will be overwritten if you have parameter ?next= specificed in the login URL.
+    "CREATE_USER": "TRUE",  # Create a new Django user when a new user logs in. Defaults to True.
+    "NEW_USER_PROFILE": {
+        "USER_GROUPS": [],  # The default group name when a new user logs in
+        "ACTIVE_STATUS": True,  # The default active status for new users
+        "STAFF_STATUS": True,  # The staff status for new users
+        "SUPERUSER_STATUS": False,  # The superuser status for new users
     },
-    'ATTRIBUTES_MAP': {  # Change Email/UserName/FirstName/LastName to corresponding SAML2 userprofile attributes.
-        'email': 'mail',
-        'username': 'uid',
-        'first_name': 'givenName',
-        'last_name': 'sn',
+    "ATTRIBUTES_MAP": {  # Change Email/UserName/FirstName/LastName to corresponding SAML2 userprofile attributes.
+        "email": "mail",
+        "username": "uid",
+        "first_name": "givenName",
+        "last_name": "sn",
     },
-    'ASSERTION_URL': os.environ.get('SAML2_AUTH_ASSERTION_URL'),
-    'ENTITY_ID': os.environ.get('SAML2_AUTH_ENTITY_ID'), # Populates the Issuer element in authn request
+    "ASSERTION_URL": os.environ.get("SAML2_AUTH_ASSERTION_URL"),
+    "ENTITY_ID": os.environ.get(
+        "SAML2_AUTH_ENTITY_ID"
+    ),  # Populates the Issuer element in authn request
 }

--- a/appstore/appstore/settings/scidas_settings.py
+++ b/appstore/appstore/settings/scidas_settings.py
@@ -1,9 +1,12 @@
 from .base import *
+from .product import ProductSettings, ProductColorScheme
 
 APPLICATION_BRAND = "scidas"
-APPLICATION_TITLE = "SciDAS"
-APPLICATION_LOGO = "/static/images/scidas/scidas-logo-sm.png"
-APPLICATION_COLOR = {
-  "primary": "#191348",
-  "secondary": "#0079bc"
-}
+
+APPLICATION_SETTINGS = ProductSettings(
+    brand="scidas",
+    title="SciDAS",
+    logo_url="/static/images/scidas/scidas-logo-sm.png",
+    color_scheme=ProductColorScheme("#191348", "#0079bc"),
+    links=None,
+)

--- a/appstore/appstore/settings/scidas_settings.py
+++ b/appstore/appstore/settings/scidas_settings.py
@@ -3,7 +3,7 @@ from .product import ProductSettings, ProductColorScheme
 
 APPLICATION_BRAND = "scidas"
 
-APPLICATION_SETTINGS = ProductSettings(
+PRODUCT_SETTINGS = ProductSettings(
     brand="scidas",
     title="SciDAS",
     logo_url="/static/images/scidas/scidas-logo-sm.png",


### PR DESCRIPTION
- Have product settings provide product links
- Refactor product settings as a dataclass for consistency
- Update serializer
- Remove conditional assignment operator for CI

cc @connectbo this will surface the product links data. The shape of the product json has changed a little, to help with consistency I moved the product settings to be represented by a [dataclass](https://github.com/helxplatform/appstore/blob/alexander/settings-update/appstore/appstore/settings/product.py), and clarified field names a bit to help with evolving this object going forward. Let me know if you have any thoughts on this.

```json
GET /api/v1/context/
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "brand": "braini",
    "title": "Brain-I",
    "logo_url": "/static/images/braini/braini-lg-gray.png",
    "color_scheme": {
        "primary": "#666666",
        "secondary": "#e6e6e6"
    },
    "links": [
        {
            "title": "Image Download",
            "link": "https://braini-metalnx.renci.org/metalnx"
        }
    ]
}
```

ref: helxplatform/development#681