### PR TITLE
Django 3.2 LTS Upgrade

### DIFF
--- a/appstore/core/apps.py
+++ b/appstore/core/apps.py
@@ -3,3 +3,4 @@ from django.apps import AppConfig
 
 class AppsCoreServicesConfig(AppConfig):
     name = 'core'
+    default_auto_field = 'django.db.models.AutoField'

--- a/appstore/core/tests.py
+++ b/appstore/core/tests.py
@@ -55,9 +55,9 @@ class AppTests(TestCase):
         response = self.client.get("/auth/")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(isinstance(response, HttpResponse))
-        header_ak, access_token = response._headers.get("access_token")
+        header_ak, access_token = response.headers._store.get("access_token")
         self.assertEqual(access_token, "")
-        header_rm, remote_user = response._headers.get("remote_user")
+        header_rm, remote_user = response.headers._store.get("remote_user")
         self.assertEqual(remote_user, "admin")
 
     def test_auth_nonloggedin_user(self):

--- a/appstore/requirements.txt
+++ b/appstore/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.1.7
+Django==3.2
 Jinja2==2.11.2 
 PrettyTable==2.0.0 
 PyYAML==5.1.2 


### PR DESCRIPTION
- Fix errors from feature deprecation/removal

Tested and everything seems to be working normally. Need to deploy this to dev with `saml` setup to test before merge to develop since https://github.com/fangli/django-saml2-auth probably won't have a specific `3.2` release in the near future. The project appears unmaintained.

Putting this in draft until django-allauth issue 2826 is closed and a new release for `3.2` is available.

ref: helxplatform/development#665