### PR TITLE
Update login routing

### DIFF
--- a/appstore/appstore/adapter.py
+++ b/appstore/appstore/adapter.py
@@ -1,11 +1,55 @@
 from allauth.account.adapter import DefaultAccountAdapter
+from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+
+from django.conf import settings
 from django.forms import ValidationError
 
 
 class RestrictEmailAdapter(DefaultAccountAdapter):
-
-    def clean_email(self,email):
-        RestrictedList = ['Your restricted list goes here.']
+    def clean_email(self, email):
+        RestrictedList = ["Your restricted list goes here."]
         if email in RestrictedList:
-            raise ValidationError('You are restricted from registering. Please contact admin.')
+            raise ValidationError(
+                "You are restricted from registering. Please contact admin."
+            )
         return email
+
+
+class LoginRedirectAdapter(DefaultAccountAdapter, DefaultSocialAccountAdapter):
+    """
+    For regular form login redirect the user to the correct
+    frontend based on where they started. Frontends set
+    a session key in the respective view class.
+
+    https://django-allauth.readthedocs.io/en/latest/advanced.html#custom-redirects
+    """
+
+    def _login_url(self, request):
+        if request.session["helx_frontend"] == "django":
+            url = "/apps/"
+        elif request.session["helx_frontend"] == "react":
+            url = "/frontend/react/"
+        else:
+            url = settings.LOGIN_REDIRECT_URL
+        return url
+
+    def _logout_url(self, request):
+        if request.session["helx_frontend"] == "django":
+            url = "/"
+        elif request.session["helx_frontend"] == "react":
+            url = "/frontend/"
+        else:
+            url = settings.ACCOUNT_LOGOUT_REDIRECT_URL
+        return url
+
+    def get_login_redirect_url(self, request):
+        return self._login_url(request)
+
+    def get_connect_redirect_url(self, request, socialaccount):
+        return self._login_url(request)
+
+    def get_logout_redirect_url(self, request):
+        url = self._logout_url(request)
+        # Unset and let the frontend set it again on landing
+        del request.session["helx_frontend"]
+        return url

--- a/appstore/appstore/settings/base.py
+++ b/appstore/appstore/settings/base.py
@@ -127,6 +127,7 @@ AUTHENTICATION_BACKENDS = (
     "allauth.account.auth_backends.AuthenticationBackend",
 )
 
+ACCOUNT_ADAPTER = "appstore.adapter.LoginRedirectAdapter"
 ACCOUNT_DEFAULT_HTTP_PROTOCOL = os.environ.get("ACCOUNT_DEFAULT_HTTP_PROTOCOL", "http")
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 1

--- a/appstore/core/views.py
+++ b/appstore/core/views.py
@@ -321,9 +321,11 @@ class IndexView(LoginView):
     redirect_field_name = "next"
 
     def get(self, request, *args, **kwargs):
+        request.session["helx_frontend"] = "django"
         if request.user.is_authenticated:
             return redirect(success_url)
         return super(LoginView, self).get(request, *args, **kwargs)
+
 
 def custom404(request, exception):
     """
@@ -337,6 +339,6 @@ def custom404(request, exception):
     if "private" in request.path:
         template_name = "private404.html"
     else:
-        template_name='404.html'
-    context = { 'req_path' : request.path }
+        template_name = "404.html"
+    context = {"req_path": request.path}
     return render(request, template_name, context=context, status=404)

--- a/appstore/frontend/views.py
+++ b/appstore/frontend/views.py
@@ -72,6 +72,7 @@ def get_brand_details():
     response = list_view(factory.get(""))
     return response.data
 
+
 class FrontendView(LoginView):
     """
     Provides the login landing page data based on allauth, customized for HeLx.
@@ -81,23 +82,24 @@ class FrontendView(LoginView):
     success_url = reverse_lazy("frontend-react")
     redirect_field_name = "next"
     brand_context = get_brand_details()
-    brand = brand_context['brand']
-    brand_logo = brand_context['logo_url']
-    brand_title = brand_context['title']
-    brand_color_scheme = brand_context['color_scheme']
-    brand_links = brand_context['links']
+    brand = brand_context["brand"]
+    brand_logo = brand_context["logo_url"]
+    brand_title = brand_context["title"]
+    brand_color_scheme = brand_context["color_scheme"]
+    brand_links = brand_context["links"]
 
     def get_context_data(self, **kwargs):
         context = super(FrontendView, self).get_context_data(**kwargs)
-        context['brand'] = self.brand
-        context['brand_logo'] = self.brand_logo
-        context['brand_title'] = self.brand_title 
-        context['brand_links'] = self.brand_links
+        context["brand"] = self.brand
+        context["brand_logo"] = self.brand_logo
+        context["brand_title"] = self.brand_title
+        context["brand_links"] = self.brand_links
         context["redirect_field_name"] = self.redirect_field_name
         context["redirect_field_value"] = self.success_url
         return context
 
     def get(self, request, *args, **kwargs):
+        request.session["helx_frontend"] = "react"
         if request.user.is_authenticated:
             return redirect(success_url)
         return super(LoginView, self).get(request, *args, **kwargs)


### PR DESCRIPTION
- Based on the login landing screen that a user interacts with determine
which frontend to route them to.
- Unset session key on logout so that it doesn't persist

This is deployed at https://helx.ahagerman.blackbalsam-cluster.edc.renci.org/ for testing.

ref: helxplatform/development#707