### PR TITLE
Context config

### DIFF
--- a/appstore/api/v1/serializers.py
+++ b/appstore/api/v1/serializers.py
@@ -92,6 +92,7 @@ class AppContextSerializer(serializers.Serializer):
     color_scheme = serializers.DictField()
     links = serializers.ListField(required=False, allow_null=True)
     capabilities = serializers.ListField()
+    env = serializers.DictField()
 
 
 class EmptySerializer(serializers.Serializer):

--- a/appstore/api/v1/views.py
+++ b/appstore/api/v1/views.py
@@ -554,7 +554,8 @@ class AppContextViewSet(viewsets.GenericViewSet):
         settings = self.get_queryset()
         data = asdict(settings.PRODUCT_SETTINGS)
         data['env'] = {}
-        for k,v in sorted(os.environ.items()): data['env'][k] = v
+        for k,v in sorted(os.environ.items()): 
+            if k in settings.EXPORTABLE_ENV: data['env'][k] = v
         serializer = self.get_serializer(data=data)
         serializer.is_valid(raise_exception=True)
         return Response(serializer.validated_data)

--- a/appstore/api/v1/views.py
+++ b/appstore/api/v1/views.py
@@ -2,10 +2,12 @@ import functools
 import logging
 from dataclasses import asdict
 import time
+import os
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth import get_user_model, logout
+from django.contrib.auth.decorators import login_required
 
 from rest_framework import status as drf_status, viewsets, serializers
 from rest_framework.permissions import IsAuthenticated, AllowAny
@@ -550,6 +552,9 @@ class AppContextViewSet(viewsets.GenericViewSet):
 
     def list(self, request):
         settings = self.get_queryset()
-        serializer = self.get_serializer(data=asdict(settings.PRODUCT_SETTINGS))
+        data = asdict(settings.PRODUCT_SETTINGS)
+        data['env'] = {}
+        for k,v in sorted(os.environ.items()): data['env'][k] = v
+        serializer = self.get_serializer(data=data)
         serializer.is_valid(raise_exception=True)
         return Response(serializer.validated_data)

--- a/appstore/appstore/settings/base.py
+++ b/appstore/appstore/settings/base.py
@@ -99,6 +99,9 @@ MIDDLEWARE = [
 ]
 
 SESSION_IDLE_TIMEOUT = int(os.environ.get("DJANGO_SESSION_IDLE_TIMEOUT", 300))
+EXPORTABLE_ENV = os.environ.get("EXPORTABLE_ENV",None)
+if EXPORTABLE_ENV != None: EXPORTABLE_ENV = EXPORTABLE_ENV.split(':')
+else: EXPORTABLE_ENV = []
 
 AUTHENTICATION_BACKENDS = (
     "django.contrib.auth.backends.RemoteUserBackend",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: helxplatform/appstore:1.1.dev3
+    image: helxplatform/appstore:context_config-0.1
     volumes:
-      - $HOME/.kube/config:/home/appstore/.kube/config
+      - $HOME/.kube/local:/home/appstore/.kube/config
       - $HOME/.minikube/:$HOME/.minikube/
     env_file:
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: helxplatform/appstore:context_config-0.1
+    image: helxplatform/appstore:context_config-0.2
     volumes:
       - $HOME/.kube/local:/home/appstore/.kube/config
       - $HOME/.minikube/:$HOME/.minikube/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     image: helxplatform/appstore:context_config-0.2
+#    image: helxplatform/appstore:oidc-0.18
     volumes:
       - $HOME/.kube/local:/home/appstore/.kube/config
       - $HOME/.minikube/:$HOME/.minikube/

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ python3-openid==3.1.0
 requests==2.20.1
 requests-oauthlib==1.3.0 
 selenium==3.141.0 
-tycho-api==1.2.dev2
+tycho-api==1.0.22
 webdriver-manager==3.2.1 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ python3-openid==3.1.0
 requests==2.20.1
 requests-oauthlib==1.3.0 
 selenium==3.141.0 
-tycho-api==1.0.22
+tycho-api==1.2.dev2
 webdriver-manager==3.2.1 


### PR DESCRIPTION
A modification to allow /context to export environment variables generically.  Guard against leaking information by requiring a special whitelist env variable **EXPORTABLE_ENV** which will contain a colon-separated list of environment variable names that are to be exported.  