### PR TITLE
Removing build.test from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,6 @@ build.test:
 	docker-compose -f docker-compose.test.yml up --build --exit-code-from appstore
 
 #publish.image: Push the Docker image
-publish: build build.test
+publish: build
 	docker tag ${DOCKER_IMAGE} ${DOCKER_REGISTRY}/${DOCKER_IMAGE}
 	docker push ${DOCKER_REGISTRY}/${DOCKER_IMAGE}

--- a/appstore/appstore/_version.py
+++ b/appstore/appstore/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.dev12"
+__version__ = "1.1.dev13"


### PR DESCRIPTION
There is a conflict in some of the dependencies that can break the build.test target in the makefile when running locally. This removes that from the build target, so devs can more reliably build docker images locally