### PR TITLE
Pinning UI image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use the ui container to pull in webpack artifacts
-FROM helxplatform/helx-ui:latest as builder
+FROM helxplatform/helx-ui:2.0.0-dev.0 as builder
 
 FROM python:3.9.0-slim
 

--- a/appstore/appstore/_version.py
+++ b/appstore/appstore/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.dev13"
+__version__ = "1.1.dev"


### PR DESCRIPTION
This change pins the UI image to a specific version in the Dockerfile
for the multi-stage build.

Previously, it would pull "helx-ui:latest". This made it impossible to
reliably replicate builds, and even without making appstore changes new
features would be pulled in. Now that the new UI is approaching a
releasable state, it is advantageous to pin to a specific version and,
as needed, update that dep through deliberate PR's.