### PR TITLE
Automatic develop builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,9 @@ pipeline {
         }
         stage('Publish') {
             when {
-                buildingTag()
+                anyOf {
+                    branch 'develop'; buildingTag()
+                }
             }
             environment {
                 DOCKERHUB_CREDS = credentials('rencibuild_dockerhub_machine_user')

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PYTHON          := /usr/bin/env python3
 VERSION_FILE    := ./appstore/appstore/_version.py
 VERSION         := $(shell grep __version__ ${VERSION_FILE} | cut -d " " -f 3 ${VERSION_FILE} | tr -d '"')
+COMMIT_HASH		:= $(shell git rev-parse --short HEAD)
 DOCKER_REGISTRY := docker.io
 DOCKER_OWNER    := helxplatform
 DOCKER_APP	    := appstore
@@ -53,6 +54,8 @@ start:
 #build: Build the Docker image
 build:
 	docker build --no-cache --pull -t ${DOCKER_IMAGE} -f Dockerfile .
+	docker tag ${DOCKER_IMAGE} ${DOCKER_REGISTRY}/${DOCKER_IMAGE}
+	docker tag ${DOCKER_IMAGE} ${DOCKER_REGISTRY}/${DOCKER_IMAGE}-${COMMIT_HASH}
 
 #build.test: Test the Docker image (requires docker compose)
 build.test:
@@ -60,5 +63,5 @@ build.test:
 
 #publish.image: Push the Docker image
 publish: build
-	docker tag ${DOCKER_IMAGE} ${DOCKER_REGISTRY}/${DOCKER_IMAGE}
 	docker push ${DOCKER_REGISTRY}/${DOCKER_IMAGE}
+	docker push ${DOCKER_REGISTRY}/${DOCKER_IMAGE}-${COMMIT_HASH}


### PR DESCRIPTION
This change alters the behavior of the Jenkinsfile to automatically
publish builds merged into the develop branch. It also adds additional
tags to the image for commit hash, so that we can more readily see what
version of the code is deployed on each environment.