### PR TITLE
Bump ui version to use the new discourse link for eduhelx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use the ui container to pull in webpack artifacts
-FROM helxplatform/helx-ui:2.0.0-dev.1 as builder
+FROM helxplatform/helx-ui:2.0.0-dev.2 as builder
 
 FROM python:3.9.0-slim
 


### PR DESCRIPTION
The new UI image updates the discourse link for eduhelx per Hannah's request.