### PR TITLE
Bug/brand logo scale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use the ui container to pull in webpack artifacts
-FROM helxplatform/helx-ui:2.0.0-dev.7 as builder
+FROM helxplatform/helx-ui:2.0.0-dev.10 as builder
 
 FROM python:3.9.0-slim
 

--- a/appstore/frontend/static/css/frontend.css
+++ b/appstore/frontend/static/css/frontend.css
@@ -758,9 +758,11 @@ form.login {
 }
 
 img#img-brand-logo {
+    height: 55px;
     width: 100%;
+    object-fit: scale-down;
     max-width: 5em;
-    padding-left: 10px;
+    padding: 0;
     margin: 0;
     position: absolute;
     top: 50%;

--- a/appstore/frontend/static/css/frontend.css
+++ b/appstore/frontend/static/css/frontend.css
@@ -762,7 +762,7 @@ img#img-brand-logo {
     width: 100%;
     object-fit: scale-down;
     max-width: 5em;
-    padding: 0;
+    padding: 2px;
     margin: 0;
     position: absolute;
     top: 50%;


### PR DESCRIPTION
This pr includes the following changes to fix the logo issue mentioned by @warrenstephens :
- on /helx login page, resized the logo at the top left, scale down if needed, added a little padding
- let AppStore use the latest UI image

Here are some screenshots:

![image](https://user-images.githubusercontent.com/33065086/140539001-ebeb13e9-fec2-4243-a809-dd7204fe63bd.png)
![image](https://user-images.githubusercontent.com/33065086/140536715-519a180f-8299-452a-b8eb-9e700fe51db7.png)
