### PR TITLE
Fix/populate env

### DIFF
--- a/bin/populate_env.sh
+++ b/bin/populate_env.sh
@@ -12,8 +12,9 @@ search_url="${REACT_APP_HELX_SEARCH_URL}"
 brand_name="${REACT_APP_UI_BRAND_NAME}"
 tranql_enabled="${REACT_APP_TRANQL_ENABLED:-false}"
 tranql_url="${REACT_APP_TRANQL_URL:-\/tranql}"
-analytics="${REACT_APP_ANALYTICS:-0c39f8410fd548bfa1976957d0248289}"
+analytics="${REACT_APP_ANALYTICS}"
 hidden_support_sections="${REACT_APP_HIDDEN_SUPPORT_SECTIONS}"
+deployment_namespace="${REACT_APP_DEPLOYMENT_NAMESPACE}"
 
 
 template='{
@@ -44,4 +45,5 @@ echo $template | sed \
   -e "s+%ANALYTICS%+$analytics+" \
   -e "s+%TRANQL_ENABLED%+$tranql_enabled+" \
   -e "s+%TRANQL_URL%+$tranql_url+" \
+  -e "s/%DEPLOYMENT_NAMESPACE%/$deployment_namespace/" \
   > $1


### PR DESCRIPTION
- Removes default Mixpanel token from `bin/populate_env` which was problematic for disabling analytics on certain deployments (as an unset/null env value was taken as the default token, rather than no token).
- Adds the deployment_namespace variable, which is used by analytics to track which namespace/deployment a particular event is originating from (much more explicit than referring to the URL domain/subdomain, for example).