### PR TITLE
Ephemeral storage testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ spec:
       limits:
         cpu: "1024m"
         memory: "2048Mi"
-        ephemeral-storage: "2816Mi"
+        ephemeral-storage: "3Gi"
     command:
     - /busybox/cat
     tty: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,11 +20,11 @@ spec:
       requests:
         cpu: "512m"
         memory: "1024Mi"
-        ephemeral-storage: "2Gi"
+        ephemeral-storage: "3Gi"
       limits:
         cpu: "1024m"
         memory: "2048Mi"
-        ephemeral-storage: "2Gi"
+        ephemeral-storage: "3Gi"
     command:
     - /busybox/cat
     tty: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,11 +20,11 @@ spec:
       requests:
         cpu: "512m"
         memory: "1024Mi"
-        ephemeral-storage: "3Gi"
+        ephemeral-storage: "2560Mi"
       limits:
         cpu: "1024m"
         memory: "2048Mi"
-        ephemeral-storage: "3Gi"
+        ephemeral-storage: "2560M"
     command:
     - /busybox/cat
     tty: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,11 +20,11 @@ spec:
       requests:
         cpu: "512m"
         memory: "1024Mi"
-        ephemeral-storage: "2560Mi"
+        ephemeral-storage: "2816Mi"
       limits:
         cpu: "1024m"
         memory: "2048Mi"
-        ephemeral-storage: "2560Mi"
+        ephemeral-storage: "2816Mi"
     command:
     - /busybox/cat
     tty: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,11 +20,11 @@ spec:
       requests:
         cpu: "512m"
         memory: "1024Mi"
-        ephemeral-storage: "3Gi"
+        ephemeral-storage: "2560Mi"
       limits:
         cpu: "1024m"
         memory: "2048Mi"
-        ephemeral-storage: "3Gi"
+        ephemeral-storage: "2560Mi"
     command:
     - /busybox/cat
     tty: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,11 +20,11 @@ spec:
       requests:
         cpu: "512m"
         memory: "1024Mi"
-        ephemeral-storage: "4Gi"
+        ephemeral-storage: "2Gi"
       limits:
         cpu: "1024m"
         memory: "2048Mi"
-        ephemeral-storage: "8Gi"
+        ephemeral-storage: "2Gi"
     command:
     - /busybox/cat
     tty: true


### PR DESCRIPTION
I was able to build the appstore image with 2816Mi set for the ephemeral storage requests and limits.  I bumped up the limit to be 3Gi to give it a little headroom.