### PR TITLE
Fixes HeLx webapp redirect for /accounts/login/ route

### DIFF
--- a/appstore/frontend/views.py
+++ b/appstore/frontend/views.py
@@ -104,7 +104,7 @@ class HelxLoginView(LoginView):
     """
 
     def get(self, request, *args, **kwargs):
-        return HttpResponsePermanentRedirect(url="/helx/workspaces/login/")
+        return redirect(to="/helx/workspaces/login/", permanent=True)
 
 
 def HelxSpaRedirectView(request):


### PR DESCRIPTION
The /accounts/login/ route stuck around, but is now supposed to redirect to the new login route, /helx/workspaces/login. This redirect was not working, so this fixes that.