### PR TITLE
breaking changes; helx-ui is now deployed separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ If changes need to happen to the frontend artifacts (react components, etc) thos
 changes will need to be done in the `helx-ui` repo which has instructions for
 developing the frontend and testing appstore integration.
 
+>NOTE: helx-ui is now deployed with it's own Helm chart and runs in it's own
+>container separate from appstore.
 
 ## Coordination of Development for Tycho and Appstore
 


### PR DESCRIPTION
I added a note in the readme about helx-ui being deployed separately now.  Feel free to edit any of that paragraph describing the frontend.  Added 'breaking' so that appstore v3.0.0 will be built when merged to master.