### PR TITLE
Pod resource additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Prerelease version is the expected next release version based on current commits
 
 [Releases](https://github.com/helxplatform/appstore/releases) are also automated following the semver specification ('major', 'minor','patch') for the project when merging `develop` branch to `master`. 
 
-For an automatic increase of the major version add a comment with "breaking|magor" in it.  For an increase in the minor version add "feat|feature|minor" in a comment.
+For an automatic increase of the major version add a comment with "breaking|major" in it.  For an increase in the minor version add "feat|feature|minor" in a comment.
 
 During a new release workflow, a new tag solidifying the semver version of the new release is first added to the master branch, then a github release object is created with release notes highlighting major, minor, patch changes and contributors for each release.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Prerelease version is the expected next release version based on current commits
 
 [Releases](https://github.com/helxplatform/appstore/releases) are also automated following the semver specification ('major', 'minor','patch') for the project when merging `develop` branch to `master`. 
 
+For an automatic increase of the major version add a comment with "breaking|magor" in it.  For an increase in the minor version add "feat|feature|minor" in a comment.
+
 During a new release workflow, a new tag solidifying the semver version of the new release is first added to the master branch, then a github release object is created with release notes highlighting major, minor, patch changes and contributors for each release.
 
 The template for the release notes may be found [here](https://github.com/helxplatform/appstore/blob/develop/.github/release.yml)

--- a/appstore/api/v1/models.py
+++ b/appstore/api/v1/models.py
@@ -10,6 +10,7 @@ class Resources:
     cpus: float
     gpus: int
     memory: str
+    ephemeralStorage: str
 
 
 @dataclass
@@ -41,6 +42,7 @@ class Instance:
     cpus: float
     gpus: int
     memory: float
+    ephemeralStorage: str
     host: InitVar[str]
     username: InitVar[str]
     url: str = field(init=False)
@@ -73,6 +75,7 @@ class ResourceRequest:
     cpus: float
     gpus: int
     memory: str
+    ephemeralStorage: str = ""
     resources: dict = None
 
     def __post_init__(self):
@@ -83,11 +86,13 @@ class ResourceRequest:
                         "cpus": self.cpus,
                         "memory": self.memory,
                         "gpus": self.gpus,
+                        "ephemeralStorage": self.ephemeralStorage,
                     },
                     "reservations": {
                         "cpus": self.cpus,
                         "memory": self.memory,
                         "gpus": self.gpus,
+                        "ephemeralStorage": self.ephemeralStorage,
                     },
                 }
             }

--- a/appstore/api/v1/serializers.py
+++ b/appstore/api/v1/serializers.py
@@ -31,6 +31,7 @@ class InstanceSerializer(serializers.Serializer):
     gpus = serializers.IntegerField(default=0)
     # TODO switch to Float potentially, or validator
     memory = serializers.CharField()
+    ephemeralStorage = serializers.CharField()
     url = serializers.CharField()
     status = serializers.CharField()
 
@@ -56,6 +57,7 @@ class ResourceSerializer(serializers.Serializer):
     cpus = serializers.FloatField()
     gpus = serializers.IntegerField(default=0)
     memory = serializers.CharField(validators=[memory_format_validator])
+    # ephemeralStorage = serializers.CharField(validators=[memory_format_validator])
 
     def create(self, validated_data):
         return ResourceRequest(**validated_data)

--- a/appstore/api/v1/serializers.py
+++ b/appstore/api/v1/serializers.py
@@ -57,6 +57,8 @@ class ResourceSerializer(serializers.Serializer):
     cpus = serializers.FloatField()
     gpus = serializers.IntegerField(default=0)
     memory = serializers.CharField(validators=[memory_format_validator])
+    # Can something like this if we add an ephemeral storage selector
+    # in the web UI.
     # ephemeralStorage = serializers.CharField(validators=[memory_format_validator])
 
     def create(self, validated_data):

--- a/appstore/api/v1/serializers.py
+++ b/appstore/api/v1/serializers.py
@@ -57,7 +57,7 @@ class ResourceSerializer(serializers.Serializer):
     cpus = serializers.FloatField()
     gpus = serializers.IntegerField(default=0)
     memory = serializers.CharField(validators=[memory_format_validator])
-    # Can something like this if we add an ephemeral storage selector
+    # Can do something like this if we add an ephemeral storage selector
     # in the web UI.
     # ephemeralStorage = serializers.CharField(validators=[memory_format_validator])
 

--- a/appstore/api/v1/views.py
+++ b/appstore/api/v1/views.py
@@ -199,13 +199,16 @@ class AppViewSet(viewsets.GenericViewSet):
                             reservations.get("cpus", 0),
                             gpu_reservations,
                             reservations.get("memory", 0),
+                            reservations.get("ephemeralStorage", 0),
                         )
                     ),
                     asdict(
                         Resources(
                             limits.get("cpus", 0),
                             gpu_limits,
-                            limits.get("memory", 0))
+                            limits.get("memory", 0),
+                            limits.get("ephemeralStorage", 0),
+                        )
                     ),
                 )
 
@@ -249,7 +252,8 @@ class AppViewSet(viewsets.GenericViewSet):
                 Resources(
                     reservations.get("cpus", 0),
                     gpu_reservations,
-                    reservations.get("memory", 0)
+                    reservations.get("memory", 0),
+                    reservations.get("ephemeralStorage", 0)
                 )
             ),
             asdict(
@@ -257,6 +261,7 @@ class AppViewSet(viewsets.GenericViewSet):
                     limits.get("cpus", 0),
                     gpu_limits,
                     limits.get("memory", 0))),
+                    limits.get("ephemeralStorage", 0)
         )
         logging.debug(f"app:\n${app}")
 
@@ -334,6 +339,7 @@ class InstanceViewSet(viewsets.GenericViewSet):
                         instance.total_util["cpu"],
                         instance.total_util["gpu"],
                         instance.total_util["memory"],
+                        instance.total_util["ephemeralStorage"],
                         host,
                         username,
                     )
@@ -422,6 +428,7 @@ class InstanceViewSet(viewsets.GenericViewSet):
                     instance.total_util["cpu"],
                     instance.total_util["gpu"],
                     instance.total_util["memory"],
+                    instance.total_util["ephemeralStorage"],
                     app.get("app_id"),
                     host,
                     username,

--- a/appstore/api/v1/views.py
+++ b/appstore/api/v1/views.py
@@ -358,8 +358,11 @@ class InstanceViewSet(viewsets.GenericViewSet):
         """
 
         serializer = self.get_serializer(data=request.data)
+        logging.debug("checking if request is valid")
         serializer.is_valid(raise_exception=True)
+        logging.debug("creating resource_request")
         resource_request = serializer.create(serializer.validated_data)
+        logging.debug(f"resource_request: {resource_request}")
         irods_enabled = os.environ.get("IROD_HOST",'').strip()
         # TODO update social query to fetch user.
         tokens = get_social_tokens(request.user)

--- a/appstore/appstore/settings/base.py
+++ b/appstore/appstore/settings/base.py
@@ -251,6 +251,10 @@ LOGGING = {
             "format": "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
             "datefmt": "%d/%b/%Y %H:%M:%S",
         },
+        "verbose2": {
+            "format": "[%(asctime)s %(levelname)s %(filename)s->%(funcName)s():%(lineno)s]: %(message)s",
+            "datefmt": "%Y-%m-%d %H:%M:%S",
+        },
         "simple": {
             "format": "[%(asctime)s] %(levelname)s %(message)s",
             "datefmt": "%d/%b/%Y %H:%M:%S",
@@ -271,7 +275,7 @@ LOGGING = {
         "console": {
             "level": LOG_LEVEL,
             "class": "logging.StreamHandler",
-            "formatter": "simple",
+            "formatter": "verbose2",
         },
         "djangoLog": {
             "level": LOG_LEVEL,

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ python3-openid==3.1.0
 requests==2.27.1
 requests-oauthlib==1.3.1
 selenium==3.141.0
-tycho-api==1.14.0.dev20230609165101
+tycho-api==1.14.0
 webdriver-manager==3.2.1
 sqlparse==0.4.2
 asgiref==3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ python3-openid==3.1.0
 requests==2.27.1
 requests-oauthlib==1.3.1
 selenium==3.141.0
-tycho-api==1.13.0
+tycho-api==1.14.0.dev20230609165101
 webdriver-manager==3.2.1
 sqlparse==0.4.2
 asgiref==3.4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     django-saml2-auth==2.2.1
     djangorestframework==3.12.2
     drf-spectacular==0.15.1
-    tycho-api==1.13.0
+    tycho-api==1.14.0.dev20230609165101
     pysaml2==6.3.1
     python3-openid==3.1.0
     requests==2.20.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     django-saml2-auth==2.2.1
     djangorestframework==3.12.2
     drf-spectacular==0.15.1
-    tycho-api==1.14.0.dev20230609165101
+    tycho-api==1.14.0
     pysaml2==6.3.1
     python3-openid==3.1.0
     requests==2.20.1


### PR DESCRIPTION
Modified so the GPU variable name used in the kubernetes deployment can be changed using an environment variable. The default is "nvidia.com/gpu", but can be set to something like "nvidia.com/mig-1g.5gb", if needed (like for Sterling). The ability to set ephemeral-storage for a pod has also been added. An "ephemeralStorage" key-value pair can be added to an app's docker-compose file in the resources section to set the limit/reservations for ephemeral storage. This is not shown in the web UI as of now. Maybe something to add later. Changes have been made in tycho, appstore and appstore-chart git repositories for these modifications.  I've also modified the logging format so that logs include the file, function name and line number.