### PR TITLE
feat: Adding whitelisting via usernames (onyens for UNC SAML)

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ appstore:
     tag: <branchname>
     pullPolicy: Always
   django:
-    AUTHORIZED_USERS: <a list emails of authorized users>
+    AUTHORIZED_USERS: <a list emails or usernames of authorized users>
     EMAIL_HOST_USER: "appstore@renci.org"
     EMAIL_HOST_PASSWORD: <secret>
     DOCKSTORE_APPS_BRANCH: <appstore branch>

--- a/appstore/core/admin.py
+++ b/appstore/core/admin.py
@@ -4,8 +4,8 @@ from core.models import AuthorizedUser
 
 
 class AuthorizedUserAdmin(admin.ModelAdmin):
-    fields = ['email']
-    list_display = 'email'
+    fields = ['email', 'username']
+    list_display = ['email', 'username']
 
 
 admin.site.register(AuthorizedUser)

--- a/appstore/core/migrations/0001_initial.py
+++ b/appstore/core/migrations/0001_initial.py
@@ -15,7 +15,8 @@ class Migration(migrations.Migration):
             name='AuthorizedUsers',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('email', models.EmailField(max_length=254)),
+                ('email', models.EmailField(max_length=254, verbose_name='Email')),
+                ('username', models.CharField(max_length=128, verbose_name='Username')),
             ],
         ),
     ]

--- a/appstore/core/models.py
+++ b/appstore/core/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django_saml2_auth.user import get_user
 
 def update_user(user):
@@ -14,14 +15,19 @@ def update_user(user):
     return _user
 
 class AuthorizedUser(models.Model):
-    email = models.EmailField(max_length=254)
+    email = models.EmailField(max_length=254, blank=True)
+    username = models.CharField(max_length=128, blank=True)
 
     def __str__(self):
-        return self.email
+        return f"{self.email}, {self.username}"
+
+    def clean(self):
+        if not self.email and not self.username:
+            raise ValidationError("Please enter a value for either email and/or username. Both cannot be empty.")
 
 class IrodAuthorizedUser(models.Model):
     user = models.TextField(max_length=254)
     uid = models.IntegerField()
 
     def __str__(self):
-        return (self.user,self.uid)
+        return f"{self.user}, {self.uid}"

--- a/appstore/middleware/filter_whitelist_middleware.py
+++ b/appstore/middleware/filter_whitelist_middleware.py
@@ -86,6 +86,11 @@ class AllowWhiteListedUserOnly(MiddlewareMixin):
             if re.match(pattern, email) is not None:
                 return True
         return False
+    
+    @staticmethod
+    def is_whitelisted_username(user):
+        username = user.username
+        
 
     @staticmethod
     def is_authorized(user):
@@ -95,6 +100,9 @@ class AllowWhiteListedUserOnly(MiddlewareMixin):
         if AllowWhiteListedUserOnly.is_auto_whitelisted_email(user):
             # authorize the user automatically, and allow them through.
             AuthorizedUser.objects.create(email=user.email)
+            return True
+        if AuthorizedUser.objects.filter(username=user.username).exists():
+            logger.debug(f"found user with username {user.username} in AuthorizedUser")
             return True
         logger.debug(f"user email {user.email} not found in AuthorizedUser")
         return False
@@ -115,6 +123,8 @@ class AllowWhiteListedUserOnly(MiddlewareMixin):
         msg = (
             "A user "
             + user.email
+            + "/"
+            + user.username
             + " is requesting access to AppStore on "
             + settings.APPLICATION_BRAND
             + " and needs to be reviewed for whitelisting. Upon successful review, kindly add the user to"

--- a/appstore/middleware/tests.py
+++ b/appstore/middleware/tests.py
@@ -62,6 +62,21 @@ class AllowWhiteListedUserOnlyTests(TestCase):
             self.groups.name,
         )
 
+    def test_login_whitelisted_username(self):
+        print("---- TESTING FOR WHITELISTED USERNAME (steve_whitelist) ----- ")
+        user = self._create_user_and_login(
+            username="Steve_whitelist", email="steve@renci.com", password="admin"
+        )
+        AuthorizedUser.objects.create(username=user.username)
+        self.request.user = user
+        self.request.session = self.client.session
+        response = self.middleware.process_request(self.request)
+        self.assertFalse(isinstance(response, HttpResponseRedirect))
+        self.assertEqual(
+            list(self.request.user.groups.values_list("name", flat=True))[0],
+            self.groups.name,
+        )
+
     def test_redirect_non_whitelisted_user(self):
         user = self._create_user_and_login(
             username="Steve_nonwhitelist",

--- a/bin/authorizeuser.py
+++ b/bin/authorizeuser.py
@@ -43,12 +43,14 @@ def irods_user_create(username,uid):
 if AUTH_USERS:
     users = re.split(r'[\s,]+',AUTH_USERS)
     for user in users:
-        if AuthorizedUser.objects.filter(email=user):
-            print(f'{"User already in Authorized Users list ----> add skipping"}')
+        is_email = re.match(r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$',user) is not None
+        is_authorized_user = AuthorizedUser.objects.filter(email=user) if is_email else AuthorizedUser.objects.filter(username=user)
+        if is_authorized_user:
+            print(f"User {user} already in Authorized Users list ----> add skipping")
         else:
-            u = AuthorizedUser(email=user)
+            u = AuthorizedUser(email=user) if is_email else AuthorizedUser(username=user)
             u.save()
-            print(f"Added {user} to the Authorized Users list ----> add success")
+            print(f"Added {user} to the Authorized Users list ----> add success")    
 
 if IROD_AUTH_USERS:
     print("IRODS USERS ENABLED")
@@ -56,14 +58,12 @@ if IROD_AUTH_USERS:
         for line in f:
             user,uid = line.split("::")
             irods_user_create(user,uid)
-        
-
-
 
 if REMOVE_AUTH_USERS:
     users = re.split(r'[\s,]+',REMOVE_AUTH_USERS)
     for user in users:
-        a_user = AuthorizedUser.objects.filter(email=user)
+        is_email = re.match(r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$',user) is not None
+        a_user = AuthorizedUser.objects.filter(email=user) if is_email else AuthorizedUser.objects.filter(username=user)
         if a_user:
             a_user.delete()
             print(f"Removed {user} from Authorized Users list ----> remove success")

--- a/bin/authorizeuser.sh
+++ b/bin/authorizeuser.sh
@@ -21,12 +21,14 @@ manageauthorizedusers () {
             for user in "${USERS[@]}"; do
                 cat <<EOF | appstore shell --settings=${BRAND_MODULE}
 from core.models import AuthorizedUser
-if AuthorizedUser.objects.filter(email="$user"):
-    print(f"User already in Authorized Users list ----> add skipping")
+is_email = re.match(r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$',user) is not None
+is_authorized_user = AuthorizedUser.objects.filter(email="$user") if is_email else AuthorizedUser.objects.filter(username="$user")
+if is_authorized_user:
+    print(f"User {"$user"} already in Authorized Users list ----> add skipping")
 else:
-    u = AuthorizedUser(email="$user")
+    u = AuthorizedUser(email="$user") if is_email else AuthorizedUser(username="$user")
     u.save()
-    print(f"Added {'$user'} to the Authorized Users list ----> add success")
+    print(f"Added {"$user"} to the Authorized Users list ----> add success")    
 EOF
             done
         fi
@@ -38,12 +40,13 @@ EOF
             for user in "${USERS[@]}"; do
                 cat <<EOF | appstore shell --settings=appstore.settings.${brand}_settings
 from core.models import AuthorizedUser
-a_user = AuthorizedUser.objects.filter(email="$user")
+is_email = re.match(r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$',user) is not None
+a_user = AuthorizedUser.objects.filter(email=$user) if is_email else AuthorizedUser.objects.filter(username=$user)
 if a_user:
     a_user.delete()
-    print(f"Removed {'$user'} from Authorized Users list ----> remove success")
+    print(f"Removed {user} from Authorized Users list ----> remove success")
 else:
-    print(f"{'$user'} not in Authorized Users list ----> remove skipping")
+    print(f"{$user} not in Authorized Users list ----> remove skipping")
 EOF
             done
         fi

--- a/bin/createtestusers.py
+++ b/bin/createtestusers.py
@@ -17,8 +17,10 @@ with open(f"{USERS_PATH}/test-users/users.txt", "r") as users:
             django_user.save()
             if AuthorizedUser.objects.filter(email=email):
                 print(f'{"User already in Authorized Users list ----> add skipping"}')
+            elif AuthorizedUser.objects.filter(username=username):
+                print(f'{"User already in Authorized Users list ----> add skipping"}')
             else:
-                u = AuthorizedUser(email=email)
+                u = AuthorizedUser(email=email, username=username)
                 u.save()
                 print(f"Added {username} to the Authorized Users list ----> add success")
         else:


### PR DESCRIPTION
This PR adds a feature to enable whitelisting by usernames. This does not remove email whitelisting because that would still be needed for Google and Github auth. So it is still backward compatible. The chart value can now have a list of emails and usernames representing "whitelisted" folks.