### PR TITLE
Tycho sessionid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ LOG_LEVEL := "info"
 endif
 
 ifeq "${DEBUG}" "true"
-LOG_LEVEL := "debug"
+LOG_LEVEL := DEBUG
 endif
 
 ifeq "${ENVS_FROM_FILE}" "true"

--- a/appstore/appstore/settings/base.py
+++ b/appstore/appstore/settings/base.py
@@ -131,6 +131,8 @@ MIDDLEWARE = [
     "allauth.account.middleware.AccountMiddleware"
 ]
 
+GRADER_API_URL = os.environ.get("GRADER_API_URL", None)
+
 SESSION_IDLE_TIMEOUT = int(os.environ.get("DJANGO_SESSION_IDLE_TIMEOUT", 300))
 EXPORTABLE_ENV = os.environ.get("EXPORTABLE_ENV",None)
 if EXPORTABLE_ENV != None: EXPORTABLE_ENV = EXPORTABLE_ENV.split(':')

--- a/appstore/core/apps.py
+++ b/appstore/core/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class AppsCoreServicesConfig(AppConfig):
     name = 'core'
+
+    def ready(self):
+        import core.signals

--- a/appstore/core/models.py
+++ b/appstore/core/models.py
@@ -1,7 +1,21 @@
+import secrets
 from django.db import models
+from django.utils import timezone
 from django.contrib.auth import get_user_model
+from django.contrib.sessions.models import Session as SessionModel
 from django.core.exceptions import ValidationError
 from django_saml2_auth.user import get_user
+from datetime import timedelta
+from string import ascii_letters, digits, punctuation
+
+UserModel = get_user_model()
+
+def generate_token():
+        token = "".join(secrets.choice(ascii_letters + digits) for i in range(256))
+        # Should realistically never occur, but it's possible.
+        while UserIdentityToken.objects.filter(token=token).exists():
+            token = "".join(secrets.choice(ascii_letters + digits) for i in range(256))
+        return token
 
 def update_user(user):
     # as of Django_saml2_auth v3.12.0 does not add email address by default
@@ -31,3 +45,23 @@ class IrodAuthorizedUser(models.Model):
 
     def __str__(self):
         return f"{self.user}, {self.uid}"
+    
+class UserIdentityToken(models.Model):
+    user = models.ForeignKey(UserModel, on_delete=models.CASCADE)
+
+    token = models.CharField(max_length=256, unique=True, default=generate_token)
+    # Optionally, identify the consumer (probably an app) whom the token was generated for.
+    consumer_id = models.CharField(max_length=256, default=None, null=True)
+    expires = models.DateTimeField(default=timezone.now() + timedelta(days=31))
+
+    @property
+    def valid(self):
+        return timezone.now() <= self.expires
+    
+    @staticmethod
+    def compute_app_consumer_id(app_id, system_id):
+        return f"{ app_id }-{ system_id }"
+
+    def __str__(self):
+        return f"{ self.user.get_username() }-token-{ self.pk }"
+        

--- a/appstore/core/urls.py
+++ b/appstore/core/urls.py
@@ -1,8 +1,11 @@
 from django.urls import path, re_path
-from .views import auth, index, HandlePrivateURL404s
+from .views import auth, auth_identity, index, HandlePrivateURL404s
 
 urlpatterns = [
     path('default/', index, name='index'),
+    # Auth based on sessionid cookie
     path("auth/", auth, name="auth"),
+    # Auth based on identity access token
+    path("auth/identity/", auth_identity, name="auth-identity"),
     re_path(r"^private/*", HandlePrivateURL404s, name="private"),
 ]

--- a/appstore/core/views.py
+++ b/appstore/core/views.py
@@ -87,14 +87,14 @@ def auth_identity(request):
     try:
         token = UserIdentityToken.objects.get(token=raw_token)
         if not token.valid:
-            return HttpResponse()
+            return HttpResponse("The token is expired. Try restarting the app.", status=401)
         remote_user = token.user.get_username()
         response = HttpResponse(remote_user, status=200)
         response["REMOTE_USER"] = remote_user
         response["ACCESS_TOKEN"] = token.token
         return response
     except UserIdentityToken.DoesNotExist:
-        return HttpResponse("The token does not exist", status=401)
+        return HttpResponse("The token does not exist. Try restarting the app.", status=401)
 
 
 @login_required

--- a/appstore/tycho/context.py
+++ b/appstore/tycho/context.py
@@ -5,6 +5,7 @@ import traceback
 import uuid
 import yaml
 import copy
+from typing import TypedDict, Optional
 from deepmerge import Merger
 from requests_cache import CachedSession
 from string import Template
@@ -283,7 +284,7 @@ class TychoContext:
     def update(self, request):
         return self.client.patch(request)
     
-    def start (self, principal, app_id, resource_request, host):
+    def start (self, principal, app_id, resource_request, host, extra_container_env={}):
         """ Get application metadata, docker-compose structure, settings, and compose API request. """
         logger.info(f"\nprincipal: {principal}\napp_id: {app_id}\n"
                     f"resource_request: {resource_request}\nhost: {host}")
@@ -301,7 +302,13 @@ class TychoContext:
         """ Use a pre-existing k8s service account """
         service_account = self.apps[app_id]['serviceAccount'] if 'serviceAccount' in self.apps[app_id].keys() else None
         """ Add entity's auth information """
-        principal_params = {"username": principal.username, "access_token": principal.access_token, "refresh_token": principal.refresh_token, "host": host}
+        principal_params = {
+            "username": principal.username,
+            "access_token": principal.access_token,
+            "refresh_token": principal.refresh_token,
+            "host": host,
+            "extra_container_env": extra_container_env
+        }
         principal_params_json = json.dumps(principal_params, indent=4)
         """ Security Context that are set for the app """
         spec["security_context"] = self.apps[app_id]["securityContext"] if 'securityContext' in self.apps[app_id].keys() else {}

--- a/appstore/tycho/model.py
+++ b/appstore/tycho/model.py
@@ -207,7 +207,9 @@ class System:
         username_remove_us = self.username.replace("_", "-")
         username_remove_dot = username_remove_us.replace(".", "-")
         self.username_all_hyphens = username_remove_dot
+        self.access_token = principal.get("access_token")
         self.host = principal.get("host")
+        self.extra_container_env = principal.get("extra_container_env", {})
         self.annotations = {}
         self.namespace = "default"
         self.serviceaccount = service_account

--- a/appstore/tycho/template/pod.yaml
+++ b/appstore/tycho/template/pod.yaml
@@ -109,6 +109,12 @@ spec:
       value: {{ system.username }}
     - name: USER
       value: {{ system.username }}
+    - name: ACCESS_TOKEN
+      value: {{ system.access_token }}
+    {% for key, value in system.extra_container_env.items() %}
+    - name: {{ key }}
+      value: {{ value }}
+    {%endfor %}
     {% if system.amb %}
     - name: NB_PREFIX
       value: /private/{{system.system_name}}/{{system.username}}/{{system.identifier}}
@@ -143,9 +149,11 @@ spec:
     {% endif %}
 {% endif %}
 {% if system.system_env %}
-  {% for env in system.system_env %}
-    - name: {{ env }}
-      value: {{ system.system_env[env]}}
+  {% for key, value in system.system_env.items() %}
+    {% if value is string or value is number or value is boolean %}
+    - name: {{ key }}
+      value: {{ value }}
+    {% endif %}
   {% endfor %}
 {% endif %}
 {% if container.expose|length > 0 %}


### PR DESCRIPTION
Modify Tycho to allow encoding arbitrary environmental variables into app pods. We now encode sessionid as `ACCESS_TOKEN` and grader API URL as `GRADER_API_URL` (if the setting in appstore is set) into pod environments.