### PR TITLE
create symlink to /shared under /home/user/shared for ordrd deployments

### DIFF
--- a/appstore/tycho/template/pod.yaml
+++ b/appstore/tycho/template/pod.yaml
@@ -74,6 +74,9 @@ spec:
         mkdir -p {{ system.parent_dir }}/{{ system.subpath_dir }}/.ssh &&
         echo -e "Host {{ system.gitea_host }}\n     Hostname {{ system.gitea_service_name }}\n     User {{ system.gitea_user }}\n     IdentityFile ~/.ssh/id_gitea" > {{ system.parent_dir }}/{{ system.subpath_dir }}/.ssh/config &&
         {% endif %}
+        if [ -d /shared ]; then
+          ln -sfn /shared {{ system.parent_dir }}/{{ system.subpath_dir }}/shared;
+        fi &&
         ls -aln {{ system.parent_dir }} &&
         echo OK
     volumeMounts:


### PR DESCRIPTION
This is in an init container which applies to all pods since it's useful to keep it consistent across filebrowser, jupyter, etc. Important to have the symlink so that users can navigate to it since the root directory is generally inaccessible in apps such as filebrowser (and even if accessible, it's an odd location).