### PR TITLE
fix port for csrf trusted origins

### DIFF
--- a/appstore/appstore/settings/base.py
+++ b/appstore/appstore/settings/base.py
@@ -374,10 +374,10 @@ if DEBUG and DEV_PHASE in ("local", "stub", "dev"):
     ]
 
     CSRF_TRUSTED_ORIGINS += [
-        "https://localhost",
-        "https://127.0.0.1",
-        "http://localhost",
-        "http://127.0.0.1",
+        "https://localhost:3000",
+        "https://127.0.0.1:3000",
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
     ]
 
     CORS_ALLOWED_ORIGINS = [


### PR DESCRIPTION
Should have named port 3000 specifically, was targetting port 80 unintentionally.