### PR TITLE
Whitelisting fix for empty emails

### DIFF
--- a/appstore/middleware/filter_whitelist_middleware.py
+++ b/appstore/middleware/filter_whitelist_middleware.py
@@ -153,7 +153,7 @@ class AllowWhiteListedUserOnly(MiddlewareMixin):
     def is_authorized(user):
         logger.debug("[AUTHZ] Testing %s / %s", user.username, user.email)
 
-        if AuthorizedUser.objects.filter(email=user.email).exists():
+        if user.email and AuthorizedUser.objects.filter(email=user.email).exists():
             logger.debug("[AUTHZ] email match in AuthorizedUser")
             return True
 


### PR DESCRIPTION
LDAP users generally have a username but no email, so whitelisting middleware was checking the authorized users table and trying to match that incoming empty email against the authorized users table, seeing that a record exists with an empty email (username but no email), and auto-whitelisting them as a result. So should only be auto-whitelisting emails if the email is actually populated.