### PR TITLE
Add pgappname to apps automatically

### DIFF
--- a/appstore/tycho/template/pod.yaml
+++ b/appstore/tycho/template/pod.yaml
@@ -250,6 +250,8 @@ spec:
       value: {{ system.username }}
     - name: ACCESS_TOKEN
       value: {{ system.access_token }}
+    - name: PGAPPNAME
+      value: {{ system.name }}
     {% for key, value in system.extra_container_env.items() %}
     - name: {{ key }}
       value: {{ value }}


### PR DESCRIPTION
Aliases `PGAPPNAME` to the `HOSTNAME` of the pod, e.g.:
```
groupe@jupyter-helx-notebook-86f16d29045f4c9fb131a4a366346fc8-8649twdl:~$ echo $PGAPPNAME
jupyter-helx-notebook-86f16d29045f4c9fb131a4a366346fc8
```