### PR TITLE
Add IfNotPresent pull policy for init containers

### DIFF
--- a/appstore/tycho/template/pod.yaml
+++ b/appstore/tycho/template/pod.yaml
@@ -52,6 +52,7 @@ spec:
   initContainers:
   - name: volume-tasks
     image: {{ system.init_image_repository }}:{{ system.init_image_tag }}
+    imagePullPolicy: IfNotPresent
     {% if system.init_security_context.run_as_user or system.init_security_context.run_as_group %}
     securityContext:
       {% if system.init_security_context.run_as_user %}
@@ -108,6 +109,7 @@ spec:
     {% endif %}
   - name: userless-volume-tasks
     image: {{ system.init_image_repository }}:{{ system.init_image_tag }}
+    imagePullPolicy: IfNotPresent
     securityContext:
       runAsUser: {{ system.init_nobody_uid }}
       runAsGroup: {{ system.init_nobody_gid }}


### PR DESCRIPTION
Busybox init containers on ASHE were hitting rate limits due to pulling from the docker registry. Since we always reuse the same busybox image, we shouldn't be repulling it on every app launch anyways.